### PR TITLE
Bluespace Chemistry Exploit Fixes + Chefs Kiss

### DIFF
--- a/Content.Goobstation.Server/Chemistry/Components/EnergyReagentDispenserComponent.cs
+++ b/Content.Goobstation.Server/Chemistry/Components/EnergyReagentDispenserComponent.cs
@@ -88,5 +88,8 @@ namespace Content.Goobstation.Server.Chemistry.Components
 
         [DataField]
         public Dictionary<string, float> Reagents = [];
+
+        [DataField]
+        public float StoredEnergySpent = 0f;
     }
 }

--- a/Content.Goobstation.Server/Chemistry/EntitySystems/EnergyReagentDispenserSystem.cs
+++ b/Content.Goobstation.Server/Chemistry/EntitySystems/EnergyReagentDispenserSystem.cs
@@ -76,9 +76,14 @@ namespace Content.Goobstation.Server.Chemistry.EntitySystems
         [Dependency] private readonly IPrototypeManager _prototypeManager = default!;
         [Dependency] private readonly BatterySystem _battery = default!;
 
+
+
         public override void Initialize()
         {
             base.Initialize();
+
+            SubscribeLocalEvent<EnergyReagentDispenserComponent,
+             EntRemovedFromContainerMessage>(OnBeakerRemoved); // JAMBOREE: Reset the stored energy when the beaker is removed to prevent exploits with swapping containers
 
             SubscribeLocalEvent<EnergyReagentDispenserComponent, ComponentStartup>(SubscribeUpdateUiState);
             SubscribeLocalEvent<EnergyReagentDispenserComponent, SolutionContainerChangedEvent>(SubscribeUpdateUiState);
@@ -211,25 +216,33 @@ namespace Content.Goobstation.Server.Chemistry.EntitySystems
                 return;
 
             _battery.SetCharge(reagentDispenser.Owner, battery.CurrentCharge - powerRequired);
+            reagentDispenser.Comp.StoredEnergySpent += powerRequired;
             ClickSound(reagentDispenser);
-            UpdateUiState(reagentDispenser);
+            UpdateUiState(reagentDispenser); // Replaced this to track the energy spent // JAMBOREE
         }
 
         private void OnClearContainerSolutionMessage(Entity<EnergyReagentDispenserComponent> reagentDispenser, ref EnergyReagentDispenserClearContainerSolutionMessage message)
         {
             var outputContainerNullable = _itemSlotsSystem.GetItemOrNull(reagentDispenser, SharedEnergyReagentDispenser.OutputSlotName);
             if (outputContainerNullable is not { Valid: true } outputContainer
-                || !_solutionContainerSystem.TryGetFitsInDispenser(outputContainer, out var solution, out var soln))
+                || !_solutionContainerSystem.TryGetFitsInDispenser(outputContainer, out var solution, out _))
                 return;
 
-            var refundedPower = soln.Sum(reagent => GetPowerCostForReagent(reagent.Reagent.Prototype, (int) reagent.Quantity, reagentDispenser));
-            if (refundedPower > 0)
-                _battery.AddCharge(reagentDispenser, refundedPower);
+            if (reagentDispenser.Comp.StoredEnergySpent > 0f)
+            {
+                _battery.AddCharge(reagentDispenser, reagentDispenser.Comp.StoredEnergySpent);
+                reagentDispenser.Comp.StoredEnergySpent = 0f; // Add restored energy back to the battery instead of a ridiculous amount. JAMBOREE
+            }
 
             _solutionContainerSystem.RemoveAllSolution(solution.Value);
             UpdateUiState(reagentDispenser);
             ClickSound(reagentDispenser);
         }
+
+        private void OnBeakerRemoved(Entity<EnergyReagentDispenserComponent> ent, ref EntRemovedFromContainerMessage args)
+        {
+        ent.Comp.StoredEnergySpent = 0f;
+        } // Remove the stored energy spent when the containers removed to prevent the exploit of swapping containers to restore energy. JAMBOREE
 
         private void ClickSound(Entity<EnergyReagentDispenserComponent> reagentDispenser) =>
             _audioSystem.PlayPvs(reagentDispenser.Comp.ClickSound, reagentDispenser, AudioParams.Default.WithVolume(-2f));

--- a/Content.Goobstation.Server/Chemistry/EntitySystems/EnergyReagentDispenserSystem.cs
+++ b/Content.Goobstation.Server/Chemistry/EntitySystems/EnergyReagentDispenserSystem.cs
@@ -82,13 +82,10 @@ namespace Content.Goobstation.Server.Chemistry.EntitySystems
         {
             base.Initialize();
 
-            SubscribeLocalEvent<EnergyReagentDispenserComponent,
-            EntRemovedFromContainerMessage>(OnBeakerRemoved); // JAMBOREE: Reset the stored energy when the beaker is removed to prevent exploits with swapping containers
-
+            SubscribeLocalEvent<EnergyReagentDispenserComponent, EntRemovedFromContainerMessage>(OnBeakerRemoved);
             SubscribeLocalEvent<EnergyReagentDispenserComponent, ComponentStartup>(SubscribeUpdateUiState);
             SubscribeLocalEvent<EnergyReagentDispenserComponent, SolutionContainerChangedEvent>(SubscribeUpdateUiState);
             SubscribeLocalEvent<EnergyReagentDispenserComponent, EntInsertedIntoContainerMessage>(SubscribeUpdateUiState);
-            SubscribeLocalEvent<EnergyReagentDispenserComponent, EntRemovedFromContainerMessage>(SubscribeUpdateUiState);
             SubscribeLocalEvent<EnergyReagentDispenserComponent, BoundUIOpenedEvent>(SubscribeUpdateUiState);
 
             SubscribeLocalEvent<EnergyReagentDispenserComponent, EnergyReagentDispenserSetDispenseAmountMessage>(OnSetDispenseAmountMessage);

--- a/Content.Goobstation.Server/Chemistry/EntitySystems/EnergyReagentDispenserSystem.cs
+++ b/Content.Goobstation.Server/Chemistry/EntitySystems/EnergyReagentDispenserSystem.cs
@@ -83,7 +83,7 @@ namespace Content.Goobstation.Server.Chemistry.EntitySystems
             base.Initialize();
 
             SubscribeLocalEvent<EnergyReagentDispenserComponent,
-             EntRemovedFromContainerMessage>(OnBeakerRemoved); // JAMBOREE: Reset the stored energy when the beaker is removed to prevent exploits with swapping containers
+            EntRemovedFromContainerMessage>(OnBeakerRemoved); // JAMBOREE: Reset the stored energy when the beaker is removed to prevent exploits with swapping containers
 
             SubscribeLocalEvent<EnergyReagentDispenserComponent, ComponentStartup>(SubscribeUpdateUiState);
             SubscribeLocalEvent<EnergyReagentDispenserComponent, SolutionContainerChangedEvent>(SubscribeUpdateUiState);

--- a/Content.Goobstation.Server/Chemistry/EntitySystems/EnergyReagentDispenserSystem.cs
+++ b/Content.Goobstation.Server/Chemistry/EntitySystems/EnergyReagentDispenserSystem.cs
@@ -241,7 +241,9 @@ namespace Content.Goobstation.Server.Chemistry.EntitySystems
 
         private void OnBeakerRemoved(Entity<EnergyReagentDispenserComponent> ent, ref EntRemovedFromContainerMessage args)
         {
-        ent.Comp.StoredEnergySpent = 0f;
+            ent.Comp.StoredEnergySpent = 0f;
+            UpdateUiState(ent); // Update the UI to reflect the reset energy when the beaker is removed. JAMBOREE
+
         } // Remove the stored energy spent when the containers removed to prevent the exploit of swapping containers to restore energy. JAMBOREE
 
         private void ClickSound(Entity<EnergyReagentDispenserComponent> reagentDispenser) =>

--- a/Resources/Locale/en-US/_Goobstation/research/technologies.ftl
+++ b/Resources/Locale/en-US/_Goobstation/research/technologies.ftl
@@ -42,3 +42,4 @@ research-technology-advanced-power-generation = Advanced Power Generation
 research-technology-bluespace-construction-storage = Bluespace Construction Storage
 research-technology-extended-communication = Extended Communications
 research-technology-radio-music-communication = Radio Music Communications
+research-technology-service-energy-chem = Organic Electrosynthesis

--- a/Resources/Prototypes/Entities/Objects/Consumable/Food/Containers/bowl.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Food/Containers/bowl.yml
@@ -93,6 +93,8 @@
     damage:
       types:
         Blunt: 5
+  - type: FitsInDispenser #Goobstation
+    solution: food
 
 - type: entity
   name: broken bowl

--- a/Resources/Prototypes/Research/civilianservices.yml
+++ b/Resources/Prototypes/Research/civilianservices.yml
@@ -363,8 +363,8 @@
   id: ServiceBluespaceChemistry
   name: research-technology-service-energy-chem
   icon:
-    sprite: _Goobstation/Structures/Machines/service_dispenser.rsi
-    state: industrial
+    sprite: _Goobstation/Objects/Specific/Hydroponics/bluespace_tomato.rsi
+    state: icon
   discipline: CivilianServices
   tier: 2
   cost: 7500

--- a/Resources/Prototypes/Research/civilianservices.yml
+++ b/Resources/Prototypes/Research/civilianservices.yml
@@ -352,24 +352,25 @@
   - MedkitCombat # Goobstation - remove medkitcombat from static to research
   - VialBluespace # goob edit - bluespace vials
   - EnergyChemDispenserMachineCircuitboard # Jamboree - add energy chem dispenser medical circuitboard to research
-  - EnergyBoozeDispenserMachineCircuitboard # Jamboree - add energy booze dispenser service circuitboard to research
-  - EnergySodaDispenserMachineCircuitboard # Jamboree - add energy soda dispenser service circuitboard to research
   # Goobstation R&D Console rework start
   position: 4,5
   technologyPrerequisites:
   - BiochemicalStasis
   # Goobstation R&D Console rework end
+
 - type: technology  # Goobstation
   id: ServiceBluespaceChemistry
   name: research-technology-service-energy-chem
   icon:
-    sprite: _Goobstation/Objects/Specific/Hydroponics/bluespace_tomato.rsi
-    state: icon
+    sprite: Objects/Specific/Hydroponics/blue_tomato.rsi
+    state: produce
   discipline: CivilianServices
   tier: 2
-  cost: 7500
+  cost: 15000
   recipeUnlocks:
   - ServiceEnergyChemMachineCircuitboard
+  - EnergyBoozeDispenserMachineCircuitboard # Jamboree - add energy booze dispenser service circuitboard to research
+  - EnergySodaDispenserMachineCircuitboard # Jamboree - add energy soda dispenser service circuitboard to research
   position: -4,7
   technologyPrerequisites:
   - MeatManipulation

--- a/Resources/Prototypes/Research/civilianservices.yml
+++ b/Resources/Prototypes/Research/civilianservices.yml
@@ -359,3 +359,17 @@
   technologyPrerequisites:
   - BiochemicalStasis
   # Goobstation R&D Console rework end
+- type: technology  # Goobstation
+  id: ServiceBluespaceChemistry
+  name: research-technology-service-energy-chem
+  icon:
+    sprite: _Goobstation/Structures/Machines/service_dispenser.rsi
+    state: industrial
+  discipline: CivilianServices
+  tier: 2
+  cost: 7500
+  recipeUnlocks:
+  - ServiceEnergyChemMachineCircuitboard
+  position: -4,7
+  technologyPrerequisites:
+  - MeatManipulation

--- a/Resources/Prototypes/_Goobstation/Entities/Objects/Devices/Circuitboards/machine.yml
+++ b/Resources/Prototypes/_Goobstation/Entities/Objects/Devices/Circuitboards/machine.yml
@@ -164,3 +164,22 @@
       stackRequirements:
         Steel: 1
         Cable: 2
+
+- type: entity  # Food synthesizer
+  parent: BaseMachineCircuitboard
+  id: ServiceEnergyChemMachineCircuitboard
+  name: energy food synthesizer machine board
+  description: A machine printed circuit board for a energy food synthesizer.
+  components:
+  - type: Sprite
+    state: service
+  - type: MachineBoard
+    prototype: ServiceEnergyChemDispenser
+    stackRequirements:
+      Manipulator: 3
+      BSCrystal: 2
+    tagRequirements:
+      GlassBeaker:
+        amount: 2
+        defaultPrototype: Beaker
+

--- a/Resources/Prototypes/_Goobstation/Entities/Structures/Machines/dispensers.yml
+++ b/Resources/Prototypes/_Goobstation/Entities/Structures/Machines/dispensers.yml
@@ -188,8 +188,8 @@
       Whiskey: 5
       Wine: 5
   - type: Battery
-    maxCharge: 2000
-    startingCharge: 400
+    maxCharge: 2500
+    startingCharge: 100
 
 
 - type: entity
@@ -232,8 +232,8 @@
       TonicWater: 5
       Water: 1
   - type: Battery
-    maxCharge: 2000
-    startingCharge: 400
+    maxCharge: 2500
+    startingCharge: 100
 
 
 
@@ -282,5 +282,5 @@
       HorseradishSauce: 4
       Cornoil: 4
   - type: Battery
-    maxCharge: 2000
-    startingCharge: 400
+    maxCharge: 3000
+    startingCharge: 100

--- a/Resources/Prototypes/_Goobstation/Entities/Structures/Machines/dispensers.yml
+++ b/Resources/Prototypes/_Goobstation/Entities/Structures/Machines/dispensers.yml
@@ -147,7 +147,7 @@
       TableSalt: 20
   - type: Battery
     maxCharge: 3000
-    startingCharge: 3000
+    startingCharge: 400
 
 
 
@@ -186,7 +186,7 @@
       Wine: 5
   - type: Battery
     maxCharge: 2000
-    startingCharge: 2000
+    startingCharge: 400
 
 
 - type: entity
@@ -229,4 +229,4 @@
       Water: 1
   - type: Battery
     maxCharge: 2000
-    startingCharge: 2000
+    startingCharge: 400

--- a/Resources/Prototypes/_Goobstation/Entities/Structures/Machines/dispensers.yml
+++ b/Resources/Prototypes/_Goobstation/Entities/Structures/Machines/dispensers.yml
@@ -260,6 +260,7 @@
       Sugar: 5
       Water: 1
       # Uncommon ingredients
+      Enzyme: 30
       Fat: 20
       UncookedAnimalProteins: 20
       MilkSoy: 16

--- a/Resources/Prototypes/_Goobstation/Entities/Structures/Machines/dispensers.yml
+++ b/Resources/Prototypes/_Goobstation/Entities/Structures/Machines/dispensers.yml
@@ -116,7 +116,7 @@
   - type: Sprite
     sprite: Structures/dispensers.rsi
     state: industrial-working
-    snapCardinals: true
+    snapCardinals: false
   - type: Machine
     board: EnergyChemDispenserMachineCircuitboard
   - type: GuideHelp
@@ -163,7 +163,7 @@
     sprite: Structures/smalldispensers.rsi
     state: booze
     drawdepth: SmallObjects
-    snapCardinals: true
+    snapCardinals: false
   - type: Rotatable
   - type: Transform
     noRot: false
@@ -202,7 +202,7 @@
     sprite: Structures/smalldispensers.rsi
     state: soda
     drawdepth: SmallObjects
-    snapCardinals: true
+    snapCardinals: false
   - type: Machine
     board: EnergySodaDispenserMachineCircuitboard
   - type: GuideHelp
@@ -246,7 +246,7 @@
   - type: Sprite
     sprite: Structures/dispensers.rsi
     state: industrial-working
-    snapCardinals: true
+    snapCardinals: false
   - type: Machine
     board: ServiceEnergyChemMachineCircuitboard
   - type: EnergyReagentDispenser

--- a/Resources/Prototypes/_Goobstation/Entities/Structures/Machines/dispensers.yml
+++ b/Resources/Prototypes/_Goobstation/Entities/Structures/Machines/dispensers.yml
@@ -87,6 +87,8 @@
   id: EnergyReagentDispenserPortableBase
   abstract: true
   parent: EnergyReagentDispenserBase
+  placement:
+    mode: SnapgridCenter
   components:
   - type: Transform
     anchored: false
@@ -161,6 +163,7 @@
     sprite: Structures/smalldispensers.rsi
     state: booze
     drawdepth: SmallObjects
+    snapCardinals: true
   - type: Rotatable
   - type: Transform
     noRot: false
@@ -199,6 +202,7 @@
     sprite: Structures/smalldispensers.rsi
     state: soda
     drawdepth: SmallObjects
+    snapCardinals: true
   - type: Machine
     board: EnergySodaDispenserMachineCircuitboard
   - type: GuideHelp
@@ -227,6 +231,56 @@
       Tea: 5
       TonicWater: 5
       Water: 1
+  - type: Battery
+    maxCharge: 2000
+    startingCharge: 400
+
+
+
+- type: entity
+  id: ServiceEnergyChemDispenser
+  parent: EnergyReagentDispenserBase
+  name: Energy food synthesizer
+  description: A bluespace food synthesizer that uses station energy to create a variety of food based reagents! Now you can create terrible food without worry and bring shame to all chefs!
+  components:
+  - type: Sprite
+    sprite: Structures/dispensers.rsi
+    state: industrial-working
+    snapCardinals: true
+  - type: Machine
+    board: ServiceEnergyChemMachineCircuitboard
+  - type: EnergyReagentDispenser
+    reagents:
+      Flour: 4
+      Cornmeal: 4
+      Rice: 4
+      Egg: 12
+      Milk: 12
+      Sugar: 5
+      Water: 1
+      # Uncommon ingredients
+      Fat: 20
+      UncookedAnimalProteins: 20
+      MilkSoy: 16
+      Oats: 14
+      Vinegar: 8
+      OilOlive: 5
+      JuiceLime: 5
+      JuicePineapple: 11
+      # Condiments
+      TableSalt: 20
+      Blackpepper: 10
+      BbqSauce: 5
+      Soysauce: 4
+      Mustard: 5
+      Ketchup: 5
+      Mayo: 5
+      Hotsauce: 6
+      Syrup: 20
+      Vinaigrette: 9
+      Astrotame: 8
+      HorseradishSauce: 4
+      Cornoil: 4
   - type: Battery
     maxCharge: 2000
     startingCharge: 400

--- a/Resources/Prototypes/_Goobstation/Entities/Structures/Machines/dispensers.yml
+++ b/Resources/Prototypes/_Goobstation/Entities/Structures/Machines/dispensers.yml
@@ -222,6 +222,7 @@
       JuiceLime: 5
       JuiceOrange: 5
       JuiceWatermelon: 5
+      JuiceTomato: 5
       LemonLime: 5
       RootBeer: 5
       SodaWater: 5

--- a/Resources/Prototypes/_Goobstation/Recipes/Lathes/misc.yml
+++ b/Resources/Prototypes/_Goobstation/Recipes/Lathes/misc.yml
@@ -29,3 +29,11 @@
   materials:
     Steel: 200
     Glass: 200
+
+- type: latheRecipe
+  id: ServiceEnergyChemMachineCircuitboard
+  parent: BaseGoldCircuitboardRecipe
+  result: ServiceEnergyChemMachineCircuitboard
+  icon:
+    sprite: _Goobstation/Structures/Machines/service_dispenser.rsi
+    state: industrial-working

--- a/Resources/Prototypes/_Goobstation/Recipes/Lathes/misc.yml
+++ b/Resources/Prototypes/_Goobstation/Recipes/Lathes/misc.yml
@@ -34,6 +34,3 @@
   id: ServiceEnergyChemMachineCircuitboard
   parent: BaseGoldCircuitboardRecipe
   result: ServiceEnergyChemMachineCircuitboard
-  icon:
-    sprite: _Goobstation/Structures/Machines/service_dispenser.rsi
-    state: industrial-working


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2021 Pieter-Jan Briers <pieterjan.briers+git@gmail.com>
SPDX-FileCopyrightText: 2021 Swept <sweptwastaken@protonmail.com>
SPDX-FileCopyrightText: 2021 mirrorcult <lunarautomaton6@gmail.com>
SPDX-FileCopyrightText: 2022 AJCM-git <60196617+AJCM-git@users.noreply.github.com>
SPDX-FileCopyrightText: 2022 Kara <lunarautomaton6@gmail.com>
SPDX-FileCopyrightText: 2023 DrSmugleaf <DrSmugleaf@users.noreply.github.com>
SPDX-FileCopyrightText: 2023 Kevin Zheng <kevinz5000@gmail.com>
SPDX-FileCopyrightText: 2024 Vasilis <vasilis@pikachu.systems>
SPDX-FileCopyrightText: 2024 lzk <124214523+lzk228@users.noreply.github.com>
SPDX-FileCopyrightText: 2025 Aiden <28298836+Aidenkrz@users.noreply.github.com>

SPDX-License-Identifier: AGPL-3.0-or-later
-->

<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- NOTE: All code submitted to this repository is ALWAYS licensed under the AGPL-3.0-or-later license. 
The REUSE Specification headers or separate .license files indicate a secondary license (e.g., MPL or MIT) solely to facilitate 
integration for projects that do not use the AGPL license. This secondary license does not replace the fact that AGPL-3.0-or-later remains the primary and binding license. 
Uncomment and modify the following line if you wish to change the license from the default of AGPL.-->
<!--- LICENSE: AGPL -->
## About the PR
<!-- What did you change? -->
There was quite a few exploits with how eChem works, mainly its refunding of energy when you clear it from the GUI. It gives you back a ridiculous amount of energy, as it didnt count for how much energy you gave back.

This means its my first C# code change, I added a value that keeps it in check.

I also tweaked the starting battery, as there was another exploit where you could dissasemble and reassemble for full battery.
Wait your turn!


I also Ported Over the Food Synthesiser from good, i.e eCondiments. They give flour, salt, pepper, and other condiments like ketchup. This was added due to popular demand from the small community.

Theres also a seperate research bit for eBooze, eSoda and eCondiments. It costs 15,000 R.P and still requires bluespace crystals to craft.
And it was also me crying fixing code.

Bowls can also be in dispensers now as its a port from goob as well.
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Well, any exploits is bad from a gameplay perspective, wait your turn rather than abusing bugs!

This was also a QoL feature too, chefs looove baking, so why not abuse bluespace for some more?

And also bowls count as containers so they should fit in dispensers
## Technical details
<!-- Summary of code changes for easier review. -->
C# Changes, mainly added a variable and subscribed to a different event in the EnergyReagentDispenser.cs file. As it didnt account for the electricity youre meant to get back.
## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
<img width="632" height="503" alt="image" src="https://github.com/user-attachments/assets/a691e3c5-7fd1-4722-ae3b-add23219f55b" />
<img width="353" height="197" alt="image" src="https://github.com/user-attachments/assets/9aae52f7-c5fe-4332-a647-2d6aee250cee" />
<img width="912" height="652" alt="image" src="https://github.com/user-attachments/assets/99b7b7fb-eb61-4ec0-872d-b4838c1555d7" />
<img width="174" height="44" alt="image" src="https://github.com/user-attachments/assets/3fd20c74-4556-4d90-bb3f-56613f31fc30" />

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->
N/A
**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Chefs unite! NanoTrasen has invested in eCondiments! The Energy Food Synthesizer is now avaliable for research! It can allow for baking ingredients like ketchup, flour, salt, pepper and more!
- add: eCondiments have their own research called "Organic Electrosynthesis". Costs 15,000R.P
- tweak: Moved eBooze and eSoda into the "Electro Synthesis" research tree.
- fix: You can no longer instantly recharge any eChem machine by simply pressing the "clear" button, it now gives you the energy back that was consumed instead of treating every reagent as 100J.
- fix: Bowls can enter dispensers
- fix: Disassembling and reassembling eChem machines doesnt give full recharge anymore.
-->
