### PR TITLE
Reach's Super Door Remote Removal, Small Central Command Updates!

### DIFF
--- a/Resources/Maps/_Jamboree/reach.yml
+++ b/Resources/Maps/_Jamboree/reach.yml
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2026 Space Station 14 Contributors
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 meta:
   format: 7
   category: Map

--- a/Resources/Maps/_Jamboree/reach.yml
+++ b/Resources/Maps/_Jamboree/reach.yml
@@ -4,7 +4,7 @@ meta:
   engineVersion: 264.0.0
   forkId: ""
   forkVersion: ""
-  time: 05/01/2026 00:32:40
+  time: 05/27/2026 04:36:58
   entityCount: 2728
 maps:
 - 1
@@ -1626,6 +1626,11 @@ entities:
       rot: -1.5707963267948966 rad
       pos: -27.5,4.5
       parent: 2
+    - type: DeviceLinkSource
+      linkedPorts:
+        2727:
+        - - DoorStatus
+          - DoorBolt
     - type: DeviceLinkSink
       invokeCounter: 1
   - uid: 2655
@@ -1634,6 +1639,11 @@ entities:
       rot: -1.5707963267948966 rad
       pos: -27.5,-3.5
       parent: 2
+    - type: DeviceLinkSource
+      linkedPorts:
+        2728:
+        - - DoorStatus
+          - DoorBolt
     - type: DeviceLinkSink
       invokeCounter: 1
   - uid: 2727
@@ -1641,6 +1651,8 @@ entities:
     - type: Transform
       pos: -26.5,5.5
       parent: 2
+    - type: DeviceLinkSink
+      invokeCounter: 1
     - type: DeviceLinkSource
       linkedPorts:
         2654:
@@ -1651,6 +1663,8 @@ entities:
     - type: Transform
       pos: -26.5,-4.5
       parent: 2
+    - type: DeviceLinkSink
+      invokeCounter: 1
     - type: DeviceLinkSource
       linkedPorts:
         2655:
@@ -5759,6 +5773,13 @@ entities:
       rot: -1.5707963267948966 rad
       pos: 20.5,-3.5
       parent: 2
+- proto: CaptainIDCard
+  entities:
+  - uid: 1648
+    components:
+    - type: Transform
+      pos: 24.659811,2.535263
+      parent: 2
 - proto: CargoTechFab
   entities:
   - uid: 774
@@ -8093,12 +8114,12 @@ entities:
     - type: Transform
       pos: 21.5,-3.5
       parent: 2
-- proto: DoorRemoteAll
+- proto: DoorRemoteCustom
   entities:
   - uid: 1078
     components:
     - type: Transform
-      pos: 24.467216,2.2952216
+      pos: 24.487936,2.316513
       parent: 2
 - proto: DrinkVodkaBottleFull
   entities:
@@ -12552,13 +12573,6 @@ entities:
     components:
     - type: Transform
       pos: -4.5,4.5
-      parent: 2
-- proto: HoPIDCard
-  entities:
-  - uid: 1648
-    components:
-    - type: Transform
-      pos: 24.607841,2.6858466
       parent: 2
 - proto: HOPUndeterminedWeapon
   entities:

--- a/Resources/Maps/centcomm.yml
+++ b/Resources/Maps/centcomm.yml
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2026 Space Station 14 Contributors
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 meta:
   format: 7
   category: Grid

--- a/Resources/Maps/centcomm.yml
+++ b/Resources/Maps/centcomm.yml
@@ -4,8 +4,8 @@ meta:
   engineVersion: 264.0.0
   forkId: ""
   forkVersion: ""
-  time: 05/01/2026 03:57:55
-  entityCount: 6975
+  time: 05/27/2026 04:47:53
+  entityCount: 6967
 maps: []
 grids:
 - 1668
@@ -3141,6 +3141,13 @@ entities:
     - type: Transform
       pos: 2.482782,35.60815
       parent: 1668
+- proto: AdvancedMicrowave
+  entities:
+  - uid: 824
+    components:
+    - type: Transform
+      pos: 2.5,-7.5
+      parent: 1668
 - proto: AirCanister
   entities:
   - uid: 1170
@@ -3892,7 +3899,7 @@ entities:
   - uid: 1737
     components:
     - type: Transform
-      pos: 15.890628,-2.4907317
+      pos: 15.570726,-2.3788633
       parent: 1668
 - proto: APCBasic
   entities:
@@ -5092,13 +5099,6 @@ entities:
     - type: Transform
       pos: 20.753271,14.277918
       parent: 1668
-- proto: BoozeDispenser
-  entities:
-  - uid: 408
-    components:
-    - type: Transform
-      pos: -6.5,4.5
-      parent: 1668
 - proto: BorgCharger
   entities:
   - uid: 2942
@@ -5111,7 +5111,7 @@ entities:
   - uid: 1370
     components:
     - type: Transform
-      pos: 15.328128,-2.3813567
+      pos: 15.117601,-2.3944883
       parent: 1668
 - proto: BoxBodyBag
   entities:
@@ -17102,13 +17102,6 @@ entities:
     - type: Transform
       pos: 0.5,-45.5
       parent: 1668
-- proto: CburnSpear
-  entities:
-  - uid: 1927
-    components:
-    - type: Transform
-      pos: 13.636442,-2.4988108
-      parent: 1668
 - proto: CdDiskDanitosBurritos
   entities:
   - uid: 543
@@ -17786,18 +17779,6 @@ entities:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 6.5,-28.5
-      parent: 1668
-- proto: ChemDispenser
-  entities:
-  - uid: 824
-    components:
-    - type: Transform
-      pos: 3.5,-13.5
-      parent: 1668
-  - uid: 1297
-    components:
-    - type: Transform
-      pos: 6.5,-13.5
       parent: 1668
 - proto: ChemistryBottleOmnizine
   entities:
@@ -19338,13 +19319,6 @@ entities:
     - type: Transform
       pos: 12.5,-7.5
       parent: 1668
-- proto: ClosetChefFilled
-  entities:
-  - uid: 416
-    components:
-    - type: Transform
-      pos: 3.5,-3.5
-      parent: 1668
 - proto: ClosetEmergencyFilledRandom
   entities:
   - uid: 2044
@@ -20203,12 +20177,36 @@ entities:
       rot: -1.5707963267948966 rad
       pos: 11.5,-7.5
       parent: 1668
+    - type: DeviceLinkSource
+      linkedPorts:
+        2086:
+        - - MedicalScannerSender
+          - CloningPodReceiver
+        - - CloningPodSender
+          - CloningPodReceiver
+        1458:
+        - - MedicalScannerSender
+          - MedicalScannerReceiver
+        - - CloningPodSender
+          - MedicalScannerReceiver
   - uid: 1508
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 11.5,-5.5
       parent: 1668
+    - type: DeviceLinkSource
+      linkedPorts:
+        319:
+        - - CloningPodSender
+          - CloningPodReceiver
+        - - MedicalScannerSender
+          - CloningPodReceiver
+        1459:
+        - - MedicalScannerSender
+          - MedicalScannerReceiver
+        - - CloningPodSender
+          - MedicalScannerReceiver
 - proto: ComputerComms
   entities:
   - uid: 3447
@@ -20324,6 +20322,14 @@ entities:
     components:
     - type: Transform
       pos: -11.5,-28.5
+      parent: 1668
+- proto: ComputerVirology
+  entities:
+  - uid: 408
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 11.5,-9.5
       parent: 1668
 - proto: ContrabandDetectorSecure
   entities:
@@ -20764,11 +20770,6 @@ entities:
       parent: 1668
 - proto: CrowbarRed
   entities:
-  - uid: 2467
-    components:
-    - type: Transform
-      pos: 22.533863,23.410753
-      parent: 1668
   - uid: 5347
     components:
     - type: Transform
@@ -20994,6 +20995,13 @@ entities:
     components:
     - type: Transform
       pos: -24.498522,4.631134
+      parent: 1668
+- proto: DiseaseDiagnoser
+  entities:
+  - uid: 1455
+    components:
+    - type: Transform
+      pos: 10.5,-9.5
       parent: 1668
 - proto: DisposalBend
   entities:
@@ -22573,13 +22581,6 @@ entities:
     - type: Transform
       pos: -24.5,12.5
       parent: 1668
-- proto: DoorRemoteAll
-  entities:
-  - uid: 6515
-    components:
-    - type: Transform
-      pos: 15.12712,-2.394535
-      parent: 1668
 - proto: Dresser
   entities:
   - uid: 3435
@@ -22821,6 +22822,32 @@ entities:
     components:
     - type: Transform
       pos: 34.26036,-3.312921
+      parent: 1668
+- proto: EnergyBoozeDispenser
+  entities:
+  - uid: 1171
+    components:
+    - type: Transform
+      pos: -6.5,4.5
+      parent: 1668
+- proto: EnergyChemDispenser
+  entities:
+  - uid: 416
+    components:
+    - type: Transform
+      pos: 6.5,-13.5
+      parent: 1668
+  - uid: 788
+    components:
+    - type: Transform
+      pos: 3.5,-13.5
+      parent: 1668
+- proto: EnergySodaDispenser
+  entities:
+  - uid: 400
+    components:
+    - type: Transform
+      pos: -5.5,4.5
       parent: 1668
 - proto: ExecutiveIDCard
   entities:
@@ -23257,7 +23284,7 @@ entities:
   - uid: 6900
     components:
     - type: Transform
-      pos: 4.420282,35.686275
+      pos: 4.4759145,35.739365
       parent: 1668
 - proto: FoodBakedGrilledCheeseSandwich
   entities:
@@ -27362,11 +27389,6 @@ entities:
       parent: 1668
 - proto: KitchenMicrowave
   entities:
-  - uid: 400
-    components:
-    - type: Transform
-      pos: 2.5,-7.5
-      parent: 1668
   - uid: 550
     components:
     - type: Transform
@@ -27876,13 +27898,6 @@ entities:
     components:
     - type: Transform
       pos: 6.605319,27.585142
-      parent: 1668
-- proto: MaintenanceWeaponSpawner
-  entities:
-  - uid: 1522
-    components:
-    - type: Transform
-      pos: 34.5,-5.5
       parent: 1668
 - proto: Mannequin
   entities:
@@ -30431,12 +30446,6 @@ entities:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 17.5,-9.5
-      parent: 1668
-  - uid: 1455
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 24.5,-8.5
       parent: 1668
   - uid: 1481
     components:
@@ -33302,6 +33311,13 @@ entities:
     - type: Transform
       pos: 6.451532,33.780025
       parent: 1668
+- proto: ServiceEnergyChemDispenser
+  entities:
+  - uid: 791
+    components:
+    - type: Transform
+      pos: 3.5,-3.5
+      parent: 1668
 - proto: SheetBrass1
   entities:
   - uid: 5884
@@ -33996,13 +34012,6 @@ entities:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 8.599574,-22.442356
-      parent: 1668
-- proto: SodaDispenser
-  entities:
-  - uid: 788
-    components:
-    - type: Transform
-      pos: -5.5,4.5
       parent: 1668
 - proto: SpaceCash1000
   entities:
@@ -36617,7 +36626,7 @@ entities:
   - uid: 706
     components:
     - type: Transform
-      pos: 16.248018,-2.4318824
+      pos: 15.883226,-2.3476133
       parent: 1668
     - type: ItemToggleMeleeWeapon
       deactivatedDamage:
@@ -36982,6 +36991,13 @@ entities:
       rot: 3.141592653589793 rad
       pos: 26.5,6.5
       parent: 1668
+- proto: Vaccinator
+  entities:
+  - uid: 1371
+    components:
+    - type: Transform
+      pos: 9.5,-9.5
+      parent: 1668
 - proto: VehicleKeySkeletonMotorcycle
   entities:
   - uid: 549
@@ -37116,10 +37132,9 @@ entities:
       parent: 1668
 - proto: VendingMachineDinnerware
   entities:
-  - uid: 791
+  - uid: 1297
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 5.5,-5.5
       parent: 1668
 - proto: VendingMachineDiscount
@@ -37178,18 +37193,6 @@ entities:
       rot: -1.5707963267948966 rad
       pos: 28.5,-11.5
       parent: 1668
-  - uid: 1484
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 10.5,-9.5
-      parent: 1668
-  - uid: 1935
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 9.5,-9.5
-      parent: 1668
 - proto: VendingMachinePwrGame
   entities:
   - uid: 6634
@@ -37236,14 +37239,6 @@ entities:
     components:
     - type: Transform
       pos: 16.5,16.5
-      parent: 1668
-- proto: VendingMachineSweetToof
-  entities:
-  - uid: 1713
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 6.5,-0.5
       parent: 1668
 - proto: VendingMachineTankDispenserEngineering
   entities:
@@ -37331,26 +37326,6 @@ entities:
           showEnts: False
           occludes: True
           ent: 1950
-- proto: WallDirectional
-  entities:
-  - uid: 1171
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 23.5,-8.5
-      parent: 1668
-  - uid: 1731
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 23.5,-9.5
-      parent: 1668
-  - uid: 1923
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 23.5,-10.5
-      parent: 1668
 - proto: WallmountTelescreen
   entities:
   - uid: 3449
@@ -43205,23 +43180,6 @@ entities:
     - type: Transform
       pos: 8.5,-2.5
       parent: 1668
-- proto: WehMedipen
-  entities:
-  - uid: 1371
-    components:
-    - type: Transform
-      pos: 13.395101,-2.4519358
-      parent: 1668
-  - uid: 2912
-    components:
-    - type: Transform
-      pos: 13.379476,-2.2644358
-      parent: 1668
-  - uid: 6161
-    components:
-    - type: Transform
-      pos: 26.429014,-8.645652
-      parent: 1668
 - proto: WelderExperimental
   entities:
   - uid: 3699
@@ -43441,6 +43399,24 @@ entities:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 13.5,-15.5
+      parent: 1668
+  - uid: 1484
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 23.5,-10.5
+      parent: 1668
+  - uid: 1522
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 23.5,-9.5
+      parent: 1668
+  - uid: 1713
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 23.5,-8.5
       parent: 1668
   - uid: 2395
     components:


### PR DESCRIPTION


<!--
SPDX-FileCopyrightText: 2021 Pieter-Jan Briers <pieterjan.briers+git@gmail.com>
SPDX-FileCopyrightText: 2021 Swept <sweptwastaken@protonmail.com>
SPDX-FileCopyrightText: 2021 mirrorcult <lunarautomaton6@gmail.com>
SPDX-FileCopyrightText: 2022 AJCM-git <60196617+AJCM-git@users.noreply.github.com>
SPDX-FileCopyrightText: 2022 Kara <lunarautomaton6@gmail.com>
SPDX-FileCopyrightText: 2023 DrSmugleaf <DrSmugleaf@users.noreply.github.com>
SPDX-FileCopyrightText: 2023 Kevin Zheng <kevinz5000@gmail.com>
SPDX-FileCopyrightText: 2024 Vasilis <vasilis@pikachu.systems>
SPDX-FileCopyrightText: 2024 lzk <124214523+lzk228@users.noreply.github.com>
SPDX-FileCopyrightText: 2025 Aiden <28298836+Aidenkrz@users.noreply.github.com>

SPDX-License-Identifier: AGPL-3.0-or-later
-->

<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- NOTE: All code submitted to this repository is ALWAYS licensed under the AGPL-3.0-or-later license. 
The REUSE Specification headers or separate .license files indicate a secondary license (e.g., MPL or MIT) solely to facilitate 
integration for projects that do not use the AGPL license. This secondary license does not replace the fact that AGPL-3.0-or-later remains the primary and binding license. 
Uncomment and modify the following line if you wish to change the license from the default of AGPL.-->
<!--- LICENSE: AGPL -->
## About the PR
<!-- What did you change? --> Removed the HOP ID and super door remote on Reach with a Spare Captain ID and a custom door remote. Replaced some walls with reinforced windows in Centcomm, added virology machines to CC, added E-Food, E-Soda, E-Booze, and E-Chem to CC.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. --> Reach change was done because the super door remote is an admeme item which can access far beyond just the captain's ID accesses, CC changes were mainly for convenience (i.e. if a virus comes to CC or if someone wanted to make a quick meal at CC, etc.)

## Technical details
<!-- Summary of code changes for easier review. -->

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [ ] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [ ] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<--
:cl:
- add: The Energy Food Synthesizer has made its way to the Jamboree Sector (thanks to PurebreadBagel in the discord!) Check out PR#280 for more details!
- tweak: Reach's HOP ID and super door remote have been replaced with a Captain ID card and a custom door remote!
- tweak: Central Command has received some small quality of life changes, such as the implementation of E-Chem/Soda/Booze/Food and the addition of some virology related machines!
-->
