### PR TITLE
Made tajaran night vision directional.

### DIFF
--- a/Content.Client/_Jamboree/Overlays/TajaranNightVisionOverlay.cs
+++ b/Content.Client/_Jamboree/Overlays/TajaranNightVisionOverlay.cs
@@ -26,7 +26,7 @@ public sealed class TajaranNightVisionOverlay
         _light = _entity.System<SharedPointLightSystem>();
     }
 
-    public void InitLight()
+    private void InitLight()
     {
         if (_lightEntity != null)
             return;
@@ -36,12 +36,10 @@ public sealed class TajaranNightVisionOverlay
         if (!_entity.TryGetComponent(player, out TransformComponent? playerXform))
             return;
 
-        _lightEntity ??= _entity.SpawnAttachedTo(null, playerXform.Coordinates);
+        _lightEntity ??= _entity.SpawnAttachedTo("TajaranNightVisionLight", playerXform.Coordinates);
         _transform.SetParent(_lightEntity.Value, player.Value);
-        var light = _entity.EnsureComponent<PointLightComponent>(_lightEntity.Value);
+        _entity.TryGetComponent<PointLightComponent>(_lightEntity.Value, out var light);
         _light.SetEnabled(_lightEntity.Value, false, light);
-        //_light.SetEnergy(_lightEntity.Value, 1f, light);
-        //_light.SetColor(_lightEntity.Value, Comp.Color, light);
     }
 
     public void RemoveLight()
@@ -52,7 +50,7 @@ public sealed class TajaranNightVisionOverlay
         _lightEntity = null;
     }
 
-    public void TurnOnLight(float lightRadius)
+    public void TurnOnLight()
     {
         if(_lightEntity == null)
             InitLight();
@@ -64,10 +62,7 @@ public sealed class TajaranNightVisionOverlay
         if (light == null)
             return;
 
-        _light.SetRadius(_lightEntity.Value, lightRadius, light);
         _light.SetEnabled(_lightEntity.Value, true, light);
-        //_light.SetEnergy(_lightEntity.Value, 1f, light);
-        //_light.SetColor(_lightEntity.Value, Comp.Color, light);
     }
 
     public void TurnOffLight()

--- a/Content.Client/_Jamboree/Overlays/TajaranNightVisionSystem.cs
+++ b/Content.Client/_Jamboree/Overlays/TajaranNightVisionSystem.cs
@@ -12,6 +12,7 @@ namespace Content.Client._Jamboree.Overlays;
 public sealed partial class TajaranNightVisionSystem : EntitySystem
 {
     [Dependency] private readonly IPlayerManager _player = default!;
+    [Dependency] private readonly IEntityManager _entity = default!;
 
     private TajaranNightVisionOverlay _overlay = default!;
 
@@ -33,7 +34,7 @@ public sealed partial class TajaranNightVisionSystem : EntitySystem
 
     private void OnToggle(Entity<TajaranNightVisionComponent> ent, ref NightVisionToggledEvent args)
     {
-        RefreshNightVision(args.Activated, args.LightRadius);
+        RefreshNightVision(args.Activated);
     }
 
     private void OnStartup(Entity<TajaranNightVisionComponent> ent, ref ComponentStartup args)
@@ -61,13 +62,13 @@ public sealed partial class TajaranNightVisionSystem : EntitySystem
         _overlay.RemoveLight();
     }
 
-    private void RefreshNightVision(bool isActive, float lightRadius = 0)
+    private void RefreshNightVision(bool isActive)
     {
         if (_player.LocalSession?.AttachedEntity is not { } entity)
             return;
 
         if (isActive)
-            _overlay.TurnOnLight(lightRadius);
+            _overlay.TurnOnLight();
         else
             _overlay.TurnOffLight();
     }

--- a/Content.Shared/_Jamboree/Overlays/SharedTajaranNightVisionSystem.cs
+++ b/Content.Shared/_Jamboree/Overlays/SharedTajaranNightVisionSystem.cs
@@ -3,9 +3,9 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
 using Content.Shared.Actions;
+using Content.Shared.Flash;
 using Robust.Shared.Audio.Systems;
 using Robust.Shared.Network;
-using Robust.Shared.Player;
 using Robust.Shared.Timing;
 
 namespace Content.Shared._Jamboree.Overlays;
@@ -22,6 +22,8 @@ public sealed class SharedTajaranNightVisionSystem : EntitySystem
         SubscribeLocalEvent<TajaranNightVisionComponent, ToggleTajaranNightVisionEvent>(OnToggle);
         SubscribeLocalEvent<TajaranNightVisionComponent, MapInitEvent>(OnMapInit);
         SubscribeLocalEvent<TajaranNightVisionComponent, ComponentShutdown>(OnShutdown);
+
+        SubscribeLocalEvent<TajaranNightVisionComponent, FlashDurationMultiplierEvent>(OnGetFlashMultiplier);
     }
 
     private void OnMapInit(EntityUid uid, TajaranNightVisionComponent component, MapInitEvent args)
@@ -35,6 +37,19 @@ public sealed class SharedTajaranNightVisionSystem : EntitySystem
         _actions.RemoveAction(uid, component.ToggleActionEntity);
     }
 
+    private void OnGetFlashMultiplier(Entity<TajaranNightVisionComponent> ent, ref FlashDurationMultiplierEvent args)
+    {
+        args.Multiplier *= GetFlashMultiplier(ent);
+    }
+
+    private float GetFlashMultiplier(TajaranNightVisionComponent comp)
+    {
+        if (!comp.IsActive)
+            return 1f;
+
+        return comp.FlashDurationMultiplier;
+    }
+
     private void OnToggle(EntityUid uid, TajaranNightVisionComponent component, ToggleTajaranNightVisionEvent args)
     {
         if (args.Handled)
@@ -42,17 +57,17 @@ public sealed class SharedTajaranNightVisionSystem : EntitySystem
 
         component.IsActive = !component.IsActive;
         _actions.SetToggled(component.ToggleActionEntity, component.IsActive);
-        RaiseNightVisionToggledEvent(uid, args.Performer, component.IsActive, component.LightRadius);
+        RaiseNightVisionToggledEvent(uid, args.Performer, component.IsActive);
 
         args.Handled = true;
         Dirty(uid, component);
     }
 
-    private void RaiseNightVisionToggledEvent(EntityUid uid, EntityUid user, bool activated, float lightRadius)
+    private void RaiseNightVisionToggledEvent(EntityUid uid, EntityUid user, bool activated)
     {
-        var ev = new NightVisionToggledEvent(user, activated, lightRadius);
+        var ev = new NightVisionToggledEvent(user, activated);
         RaiseLocalEvent(uid, ref ev);
     }
 }
 [ByRefEvent]
-public record struct NightVisionToggledEvent(EntityUid User, bool Activated, float LightRadius);
+public record struct NightVisionToggledEvent(EntityUid User, bool Activated);

--- a/Content.Shared/_Jamboree/Overlays/TajaranNightVisionComponent.cs
+++ b/Content.Shared/_Jamboree/Overlays/TajaranNightVisionComponent.cs
@@ -3,7 +3,6 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
 using Content.Shared.Actions;
-using Robust.Shared.Audio;
 using Robust.Shared.GameStates;
 using Robust.Shared.Prototypes;
 
@@ -16,7 +15,7 @@ public sealed partial class TajaranNightVisionComponent : Component
     public bool IsActive;
 
     [DataField]
-    public float LightRadius = 8;
+    public float FlashDurationMultiplier = 1.5f;
 
     [DataField]
     public EntProtoId? ToggleAction { get; set; } = "ToggleTajaranNightVision";
@@ -26,3 +25,4 @@ public sealed partial class TajaranNightVisionComponent : Component
 }
 
 public sealed partial class ToggleTajaranNightVisionEvent : InstantActionEvent;
+

--- a/Resources/Prototypes/_Jamboree/Actions/types.yml
+++ b/Resources/Prototypes/_Jamboree/Actions/types.yml
@@ -12,7 +12,6 @@
   - type: Action
     itemIconStyle: BigAction
     priority: -20
-    useDelay: 1
     clientExclusive: true
     icon:
       sprite: _White/Clothing/Eyes/Goggles/nightvision.rsi

--- a/Resources/Prototypes/_Jamboree/Body/Organs/tajaran.yml
+++ b/Resources/Prototypes/_Jamboree/Body/Organs/tajaran.yml
@@ -13,5 +13,4 @@
     - state: eyes
   - type: Organ
     onAdd:
-    - type: FlashVulnerable
     - type: TajaranNightVision

--- a/Resources/Prototypes/_Jamboree/Entities/light.yml
+++ b/Resources/Prototypes/_Jamboree/Entities/light.yml
@@ -1,0 +1,11 @@
+- type: entity
+  id: TajaranNightVisionLight
+  categories: [ HideSpawnMenu ]
+  components:
+  - type: PointLight
+    enabled: false
+    radius: 13
+    energy: 1.5
+    falloff: 0
+    mask: /Textures/Effects/LightMasks/cone.png
+    autoRot: true

--- a/Resources/Prototypes/_Jamboree/Entities/light.yml
+++ b/Resources/Prototypes/_Jamboree/Entities/light.yml
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2026 Space Station 14 Contributors
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 - type: entity
   id: TajaranNightVisionLight
   categories: [ HideSpawnMenu ]


### PR DESCRIPTION
## About the PR
<!-- What did you change? -->
I removed FlashVulnerable from tajaran eyes, because tajaran being unable to have flash protection was not intended. I added flash duration multiplication instead, as was initially intended. Also made night vision directional.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Being flash vulnerable like shadowkin is too much for this type of night vision.
Tajaran night vision was intended to be directional from the beginning, but I didn't figure out how to implement it until now.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
<img width="1335" height="1080" alt="Tajaran night vision tweak showcase" src="https://github.com/user-attachments/assets/98080db3-c11e-45d0-98a3-83c56e7f3a4d" />

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- fix: Tajaran are no longer unable to protect themselves from flashes. But will now be stunned by flashes for a longer duration when they have no flash protection.
- tweak: Tajaran night vision is now stronger, but directional.
