### PR TITLE
Hopefully fixed tajaran night vision de-sync.

### DIFF
--- a/Content.Client/_Jamboree/Overlays/TajaranNightVisionOverlay.cs
+++ b/Content.Client/_Jamboree/Overlays/TajaranNightVisionOverlay.cs
@@ -37,7 +37,10 @@ public sealed class TajaranNightVisionOverlay
             return;
 
         _lightEntity ??= _entity.SpawnAttachedTo("TajaranNightVisionLight", playerXform.Coordinates);
+
         _transform.SetParent(_lightEntity.Value, player.Value);
+        _transform.SetWorldRotation(_lightEntity.Value, _transform.GetWorldRotation((EntityUid)player));
+
         _entity.TryGetComponent<PointLightComponent>(_lightEntity.Value, out var light);
         _light.SetEnabled(_lightEntity.Value, false, light);
     }
@@ -61,6 +64,12 @@ public sealed class TajaranNightVisionOverlay
         _entity.TryGetComponent<PointLightComponent>(_lightEntity.Value, out var light);
         if (light == null)
             return;
+
+        var player = _player.LocalEntity;
+
+        if (!_entity.TryGetComponent(player, out TransformComponent? playerXform))
+            return;
+        _transform.SetWorldRotation(_lightEntity.Value, _transform.GetWorldRotation((EntityUid)player));
 
         _light.SetEnabled(_lightEntity.Value, true, light);
     }


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2021 Pieter-Jan Briers <pieterjan.briers+git@gmail.com>
SPDX-FileCopyrightText: 2021 Swept <sweptwastaken@protonmail.com>
SPDX-FileCopyrightText: 2021 mirrorcult <lunarautomaton6@gmail.com>
SPDX-FileCopyrightText: 2022 AJCM-git <60196617+AJCM-git@users.noreply.github.com>
SPDX-FileCopyrightText: 2022 Kara <lunarautomaton6@gmail.com>
SPDX-FileCopyrightText: 2023 DrSmugleaf <DrSmugleaf@users.noreply.github.com>
SPDX-FileCopyrightText: 2023 Kevin Zheng <kevinz5000@gmail.com>
SPDX-FileCopyrightText: 2024 Vasilis <vasilis@pikachu.systems>
SPDX-FileCopyrightText: 2024 lzk <124214523+lzk228@users.noreply.github.com>
SPDX-FileCopyrightText: 2025 Aiden <28298836+Aidenkrz@users.noreply.github.com>

SPDX-License-Identifier: AGPL-3.0-or-later
-->

<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- NOTE: All code submitted to this repository is ALWAYS licensed under the AGPL-3.0-or-later license. 
The REUSE Specification headers or separate .license files indicate a secondary license (e.g., MPL or MIT) solely to facilitate 
integration for projects that do not use the AGPL license. This secondary license does not replace the fact that AGPL-3.0-or-later remains the primary and binding license. 
Uncomment and modify the following line if you wish to change the license from the default of AGPL.-->
<!--- LICENSE: AGPL -->
## About the PR
<!-- What did you change? -->
Made night vision reset rotation when toggled.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
This should hopefully fix night vision rotation de-sync, by letting players refresh night vision.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- fix: You can now toggle the night vision off and back on to fix tajran night vision rotation de-sync.
