### PR TITLE
Emergichem fixes+no more universal translation

### DIFF
--- a/Content.Goobstation.Server/TapeRecorder/TapeRecorderSystem.cs
+++ b/Content.Goobstation.Server/TapeRecorder/TapeRecorderSystem.cs
@@ -11,6 +11,7 @@ using Content.Server.Speech.Components;
 using Content.Shared.Chat;
 using Content.Shared.Paper;
 using Content.Shared.Speech;
+using Content.Shared._EinsteinEngines.Language.Systems;
 using Content.Goobstation.Shared.TapeRecorder;
 using Robust.Shared.Prototypes;
 using System.Text;
@@ -21,6 +22,7 @@ public sealed class TapeRecorderSystem : SharedTapeRecorderSystem
 {
     [Dependency] private readonly ChatSystem _chat = default!;
     [Dependency] private readonly HandsSystem _hands = default!;
+    [Dependency] private readonly SharedLanguageSystem _language = default!;
     [Dependency] private readonly IPrototypeManager _proto = default!;
     [Dependency] private readonly PaperSystem _paper = default!;
 
@@ -72,6 +74,13 @@ public sealed class TapeRecorderSystem : SharedTapeRecorderSystem
         if (!TryGetTapeCassette(ent, out var cassette))
             return;
 
+        // Einstein Engines - Language
+        // The recorder is a machine that only understands universal languages. For any other language it records
+        // the same gibberish a non-understanding listener would hear, so a tape can't be used as a universal translator.
+        var message = args.Message;
+        if (!_language.CanUnderstand(ent.Owner, args.Language.ID))
+            message = _language.ObfuscateSpeech(message, args.Language);
+
         // TODO: Handle "Someone" when whispering from far away, needs chat refactor
 
         //Handle someone using a voice changer
@@ -81,7 +90,7 @@ public sealed class TapeRecorderSystem : SharedTapeRecorderSystem
         //Add a new entry to the tape
         var verb = _chat.GetSpeechVerb(args.Source, args.Message);
         var name = nameEv.VoiceName;
-        cassette.Comp.Buffer.Add(new TapeCassetteRecordedMessage(cassette.Comp.CurrentPosition, name, verb, args.Message));
+        cassette.Comp.Buffer.Add(new TapeCassetteRecordedMessage(cassette.Comp.CurrentPosition, name, verb, message));
     }
 
     private void OnPrintMessage(Entity<TapeRecorderComponent> ent, ref PrintTapeRecorderMessage args)

--- a/Content.Goobstation.Server/TapeRecorder/TapeRecorderSystem.cs
+++ b/Content.Goobstation.Server/TapeRecorder/TapeRecorderSystem.cs
@@ -74,11 +74,11 @@ public sealed class TapeRecorderSystem : SharedTapeRecorderSystem
         if (!TryGetTapeCassette(ent, out var cassette))
             return;
 
-        // Einstein Engines - Language
-        // The recorder is a machine that only understands universal languages. For any other language it records
-        // the same gibberish a non-understanding listener would hear, so a tape can't be used as a universal translator.
+        // Only record languages the recorder understands verbatim. Any other language is recorded as
+        // the same gibberish a non-understanding listener would hear, so a tape can't be used as a
+        // universal translator for exotic or secret languages.
         var message = args.Message;
-        if (!_language.CanUnderstand(ent.Owner, args.Language.ID))
+        if (!ent.Comp.UnderstoodLanguages.Contains(args.Language.ID))
             message = _language.ObfuscateSpeech(message, args.Language);
 
         // TODO: Handle "Someone" when whispering from far away, needs chat refactor

--- a/Content.Goobstation.Server/TapeRecorder/TapeRecorderSystem.cs
+++ b/Content.Goobstation.Server/TapeRecorder/TapeRecorderSystem.cs
@@ -53,8 +53,9 @@ public sealed class TapeRecorderSystem : SharedTapeRecorderSystem
             // TODO: mimic the exact string chosen when the message was recorded
             var verb = message.Verb ?? SharedChatSystem.DefaultSpeechVerb;
             speech.SpeechVerb = _proto.Index<SpeechVerbPrototype>(verb);
-            //Play the message
-            _chat.TrySendInGameICMessage(ent, message.Message, InGameICChatType.Speak, false);
+            //Play the message back in the language it was originally heard in
+            var languageOverride = message.Language is { } language ? _language.GetLanguagePrototype(language) : null;
+            _chat.TrySendInGameICMessage(ent, message.Message, InGameICChatType.Speak, ChatTransmitRange.Normal, false, languageOverride: languageOverride);
         }
     }
 
@@ -74,12 +75,12 @@ public sealed class TapeRecorderSystem : SharedTapeRecorderSystem
         if (!TryGetTapeCassette(ent, out var cassette))
             return;
 
-        // Only record languages the recorder understands verbatim. Any other language is recorded as
-        // the same gibberish a non-understanding listener would hear, so a tape can't be used as a
-        // universal translator for exotic or secret languages.
-        var message = args.Message;
+        // Only record the raw message for languages the recorder understands verbatim. Any other language
+        // gets its writing obfuscated, so a transcript can't be used as a universal translator for exotic
+        // or secret languages, while playback still reproduces the language it heard.
+        string? obfuscatedMessage = null;
         if (!ent.Comp.UnderstoodLanguages.Contains(args.Language.ID))
-            message = _language.ObfuscateSpeech(message, args.Language);
+            obfuscatedMessage = _language.ObfuscateSpeech(args.Message, args.Language);
 
         // TODO: Handle "Someone" when whispering from far away, needs chat refactor
 
@@ -90,7 +91,7 @@ public sealed class TapeRecorderSystem : SharedTapeRecorderSystem
         //Add a new entry to the tape
         var verb = _chat.GetSpeechVerb(args.Source, args.Message);
         var name = nameEv.VoiceName;
-        cassette.Comp.Buffer.Add(new TapeCassetteRecordedMessage(cassette.Comp.CurrentPosition, name, verb, message));
+        cassette.Comp.Buffer.Add(new TapeCassetteRecordedMessage(cassette.Comp.CurrentPosition, name, verb, args.Message, args.Language.ID, obfuscatedMessage));
     }
 
     private void OnPrintMessage(Entity<TapeRecorderComponent> ent, ref PrintTapeRecorderMessage args)
@@ -131,7 +132,7 @@ public sealed class TapeRecorderSystem : SharedTapeRecorderSystem
             text.AppendLine(Loc.GetString("tape-recorder-print-message-text",
                 ("time", time.ToString(@"hh\:mm\:ss")),
                 ("source", name),
-                ("message", message.Message)));
+                ("message", message.ObfuscatedMessage ?? message.Message)));
         }
         text.AppendLine();
         text.Append(Loc.GetString("tape-recorder-print-end-text"));

--- a/Content.Goobstation.Shared/TapeRecorder/Components/TapeRecorderComponent.cs
+++ b/Content.Goobstation.Shared/TapeRecorder/Components/TapeRecorderComponent.cs
@@ -6,6 +6,7 @@
 //
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
+using Content.Shared._EinsteinEngines.Language;
 using Robust.Shared.Audio;
 using Robust.Shared.GameStates;
 using Robust.Shared.Prototypes;
@@ -17,6 +18,14 @@ namespace Content.Goobstation.Shared.TapeRecorder;
 [AutoGenerateComponentState, AutoGenerateComponentPause]
 public sealed partial class TapeRecorderComponent : Component
 {
+    /// <summary>
+    /// Languages the recorder understands and records verbatim. Any other language is recorded as
+    /// the same gibberish a non-understanding listener would hear, so a tape can't be used as a
+    /// universal translator for exotic or secret languages.
+    /// </summary>
+    [DataField]
+    public List<ProtoId<LanguagePrototype>> UnderstoodLanguages = [];
+
     /// <summary>
     /// The current tape recorder mode, controls what using the item will do
     /// </summary>

--- a/Content.Goobstation.Shared/TapeRecorder/Systems/SharedTapeRecorderSystem.cs
+++ b/Content.Goobstation.Shared/TapeRecorder/Systems/SharedTapeRecorderSystem.cs
@@ -314,17 +314,24 @@ public abstract class SharedTapeRecorderSystem : EntitySystem
 
         var corruption = Loc.GetString("tape-recorder-message-corruption");
 
-        var corruptedMessage = new StringBuilder();
-        foreach (var character in entry.Message)
+        string Corrupt(string text)
         {
-            if (_random.Prob(tape.CorruptionChance))
-                corruptedMessage.Append(corruption);
-            else
-                corruptedMessage.Append(character);
+            var corruptedMessage = new StringBuilder();
+            foreach (var character in text)
+            {
+                if (_random.Prob(tape.CorruptionChance))
+                    corruptedMessage.Append(corruption);
+                else
+                    corruptedMessage.Append(character);
+            }
+
+            return corruptedMessage.ToString();
         }
 
         entry.Name = Loc.GetString("tape-recorder-voice-unintelligible");
-        entry.Message = corruptedMessage.ToString();
+        entry.Message = Corrupt(entry.Message);
+        if (entry.ObfuscatedMessage != null)
+            entry.ObfuscatedMessage = Corrupt(entry.ObfuscatedMessage);
     }
 
     /// <summary>

--- a/Content.Goobstation.Shared/TapeRecorder/TapeCasetteRecordedMessage.cs
+++ b/Content.Goobstation.Shared/TapeRecorder/TapeCasetteRecordedMessage.cs
@@ -5,6 +5,7 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
 using Content.Shared.Speech;
+using Content.Shared._EinsteinEngines.Language;
 using Robust.Shared.Prototypes;
 
 namespace Content.Goobstation.Shared.TapeRecorder;
@@ -34,17 +35,32 @@ public sealed partial class TapeCassetteRecordedMessage : IComparable<TapeCasset
     public ProtoId<SpeechVerbPrototype>? Verb;
 
     /// <summary>
-    /// What was spoken
+    /// What was spoken, as heard. This is what gets played back.
     /// </summary>
     [DataField]
     public string Message = string.Empty;
 
-    public TapeCassetteRecordedMessage(float timestamp, string name, ProtoId<SpeechVerbPrototype> verb, string message)
+    /// <summary>
+    /// What the recorder writes down for this message. Obfuscated for languages the
+    /// recorder doesn't understand, null if it recorded the message verbatim.
+    /// </summary>
+    [DataField]
+    public string? ObfuscatedMessage;
+
+    /// <summary>
+    /// The language the message was spoken in, so playback can reproduce it faithfully.
+    /// </summary>
+    [DataField]
+    public ProtoId<LanguagePrototype>? Language;
+
+    public TapeCassetteRecordedMessage(float timestamp, string name, ProtoId<SpeechVerbPrototype> verb, string message, ProtoId<LanguagePrototype>? language = null, string? obfuscatedMessage = null)
     {
         Timestamp = timestamp;
         Name = name;
         Verb = verb;
         Message = message;
+        Language = language;
+        ObfuscatedMessage = obfuscatedMessage;
     }
 
     public int CompareTo(TapeCassetteRecordedMessage? other)

--- a/Content.Server/Power/EntitySystems/ChargerSystem.cs
+++ b/Content.Server/Power/EntitySystems/ChargerSystem.cs
@@ -291,7 +291,18 @@ internal sealed class ChargerSystem : EntitySystem
         switch (component.Status)
         {
             case CellChargerStatus.Off:
-                receiver.Load = 0;
+                // If we're off because the power is out, keep requesting the charging load.
+                // Zeroing it here would make the receiver report itself as powered again
+                // (Powered is derived from Load), flip the charger back to Charging, and start
+                // a per-tick feedback loop that flickers the charger and sneaks charge into
+                // the cell while the grid is dead.
+                receiver.Load = !receiver.Powered
+                                && !HasComp<EmpDisabledComponent>(uid)
+                                && container.ContainedEntities.Count > 0
+                                && SearchForBattery(container.ContainedEntities[0], out var offBatteryUid, out var offBattery)
+                                && !_battery.IsFull(offBatteryUid.Value, offBattery)
+                    ? component.ChargeRate
+                    : 0;
                 _appearance.SetData(uid, CellVisual.Light, CellChargerStatus.Off, appearance);
                 break;
             case CellChargerStatus.Empty:

--- a/Content.Server/Spawners/EntitySystems/SpawnOnDespawnSystem.cs
+++ b/Content.Server/Spawners/EntitySystems/SpawnOnDespawnSystem.cs
@@ -51,8 +51,7 @@ public sealed partial class SpawnOnDespawnSystem : EntitySystem // Starlight edi
         while (_queuedSpawns.Count > 0)
         {
             var (prototype, coordinates, overrides) = _queuedSpawns.Dequeue();
-            var uid = Spawn(prototype, overrides);
-            _xform.SetCoordinates(uid, coordinates);
+            var uid = EntityManager.SpawnAtPosition(prototype, coordinates, overrides);
         }
     }
     // Starlight End

--- a/Content.Server/Speech/EntitySystems/ListeningSystem.cs
+++ b/Content.Server/Speech/EntitySystems/ListeningSystem.cs
@@ -10,6 +10,7 @@
 
 using Content.Server.Chat.Systems;
 using Content.Server.Speech.Components;
+using Content.Shared._EinsteinEngines.Language;
 
 namespace Content.Server.Speech.EntitySystems;
 
@@ -29,10 +30,10 @@ public sealed class ListeningSystem : EntitySystem
 
     private void OnSpeak(EntitySpokeEvent ev)
     {
-        PingListeners(ev.Source, ev.Message, ev.IsWhisper); // Einstein Engines - Languages
+        PingListeners(ev.Source, ev.Message, ev.IsWhisper, ev.Language); // Einstein Engines - Languages
     }
 
-    public void PingListeners(EntityUid source, string message, bool isWhisper) // Einstein Engines - Language
+    public void PingListeners(EntityUid source, string message, bool isWhisper, LanguagePrototype language) // Einstein Engines - Language
     {
         // TODO whispering / audio volume? Microphone sensitivity?
         // for now, whispering just arbitrarily reduces the listener's max range.
@@ -42,8 +43,8 @@ public sealed class ListeningSystem : EntitySystem
         var sourcePos = _xforms.GetWorldPosition(sourceXform, xformQuery);
 
         var attemptEv = new ListenAttemptEvent(source);
-        var ev = new ListenEvent(message, source);
-        var obfuscatedEv = !isWhisper ? null : new ListenEvent(_chat.ObfuscateMessageReadability(message), source); // Einstein Engines - Language
+        var ev = new ListenEvent(message, source, language);
+        var obfuscatedEv = !isWhisper ? null : new ListenEvent(_chat.ObfuscateMessageReadability(message), source, language); // Einstein Engines - Language
         var query = EntityQueryEnumerator<ActiveListenerComponent, TransformComponent>();
 
         while(query.MoveNext(out var listenerUid, out var listener, out var xform))

--- a/Content.Server/Speech/ListenEvent.cs
+++ b/Content.Server/Speech/ListenEvent.cs
@@ -3,17 +3,21 @@
 //
 // SPDX-License-Identifier: MIT
 
+using Content.Shared._EinsteinEngines.Language;
+
 namespace Content.Server.Speech;
 
 public sealed class ListenEvent : EntityEventArgs
 {
     public readonly string Message;
     public readonly EntityUid Source;
+    public readonly LanguagePrototype Language; // Einstein Engines - Language
 
-    public ListenEvent(string message, EntityUid source)
+    public ListenEvent(string message, EntityUid source, LanguagePrototype language) // Einstein Engines - Language
     {
         Message = message;
         Source = source;
+        Language = language;
     }
 }
 

--- a/Content.Server/_EinsteinEngines/Language/TranslatorImplantSystem.cs
+++ b/Content.Server/_EinsteinEngines/Language/TranslatorImplantSystem.cs
@@ -7,13 +7,16 @@ using Content.Shared.Implants.Components;
 using Content.Shared._EinsteinEngines.Language;
 using Content.Shared._EinsteinEngines.Language.Components;
 using Content.Shared._EinsteinEngines.Language.Events;
+using Content.Shared._EinsteinEngines.Language.Systems;
 using Robust.Shared.Containers;
+using Robust.Shared.Prototypes;
 
 namespace Content.Server._EinsteinEngines.Language;
 
 public sealed class TranslatorImplantSystem : EntitySystem
 {
     [Dependency] private readonly LanguageSystem _language = default!;
+    [Dependency] private readonly IPrototypeManager _proto = default!;
 
     public override void Initialize()
     {
@@ -81,6 +84,20 @@ public sealed class TranslatorImplantSystem : EntitySystem
             if (translator.UnderstoodRequirementSatisfied)
                 foreach (var language in translator.UnderstoodLanguages)
                     args.UnderstoodLanguages.Add(language);
+
+            // Centcomm implanter code. Basically gives you all the languages to speak as well as understanding it -- JAMBOREE!
+            if (!translator.AddUniversalLanguageSpeaker)
+                continue;
+
+            if (translator.SpokenRequirementSatisfied)
+                foreach (var language in _proto.EnumeratePrototypes<LanguagePrototype>())
+                    if (language.ID != SharedLanguageSystem.UniversalPrototype && language.ID != SharedLanguageSystem.PsychomanticPrototype)
+                        args.SpokenLanguages.Add(language.ID);
+
+            if (translator.UnderstoodRequirementSatisfied)
+                foreach (var language in _proto.EnumeratePrototypes<LanguagePrototype>())
+                    if (language.ID != SharedLanguageSystem.UniversalPrototype && language.ID != SharedLanguageSystem.PsychomanticPrototype)
+                        args.UnderstoodLanguages.Add(language.ID);
         }
     }
 }

--- a/Content.Server/_EinsteinEngines/Language/TranslatorImplantSystem.cs
+++ b/Content.Server/_EinsteinEngines/Language/TranslatorImplantSystem.cs
@@ -40,16 +40,30 @@ public sealed class TranslatorImplantSystem : EntitySystem
         component.UnderstoodRequirementSatisfied = TranslatorSystem.CheckLanguagesMatch(
             component.RequiredLanguages, knowledge.UnderstoodLanguages, component.RequiresAllLanguages);
 
+        if (component.AddUniversalLanguageSpeaker
+            && component.SpokenRequirementSatisfied
+            && component.UnderstoodRequirementSatisfied
+            && !component.AddedUniversalLanguageSpeaker)
+        {
+            EnsureComp<UniversalLanguageSpeakerComponent>(implantee);
+            component.AddedUniversalLanguageSpeaker = true;
+        }
+
         _language.UpdateEntityLanguages(implantee);
     }
 
     private void OnDeImplant(EntityUid uid, TranslatorImplantComponent component, EntGotRemovedFromContainerMessage args)
     {
         // Even though the description of this event says it gets raised BEFORE reparenting, that's actually false...
-        component.Enabled = component.SpokenRequirementSatisfied = component.UnderstoodRequirementSatisfied = false;
+        if (TryComp<SubdermalImplantComponent>(uid, out var subdermal) && subdermal.ImplantedEntity is { Valid: true } implantee)
+        {
+            if (component.AddedUniversalLanguageSpeaker)
+                RemComp<UniversalLanguageSpeakerComponent>(implantee);
 
-        if (TryComp<SubdermalImplantComponent>(uid, out var subdermal) && subdermal.ImplantedEntity is { Valid: true} implantee)
             _language.UpdateEntityLanguages(implantee);
+        }
+
+        component.Enabled = component.SpokenRequirementSatisfied = component.UnderstoodRequirementSatisfied = component.AddedUniversalLanguageSpeaker = false;
     }
 
     private void OnDetermineLanguages(EntityUid uid, ImplantedComponent component, ref DetermineEntityLanguagesEvent args)

--- a/Content.Shared/_EinsteinEngines/Language/Components/TranslatorImplantComponent.cs
+++ b/Content.Shared/_EinsteinEngines/Language/Components/TranslatorImplantComponent.cs
@@ -18,4 +18,16 @@ public sealed partial class TranslatorImplantComponent : BaseTranslatorComponent
     ///     Whether the implantee knows the languages necessary to understand translations of this implant.
     /// </summary>
     public bool UnderstoodRequirementSatisfied = false;
+
+    /// <summary>
+    ///     If true, grants the implantee the <see cref="UniversalLanguageSpeakerComponent"/> ability,
+    ///     letting them understand and speak any language.
+    /// </summary>
+    [DataField("universalLanguageSpeaker")]
+    public bool AddUniversalLanguageSpeaker = false;
+
+    /// <summary>
+    ///     Whether this implant added the universal language speaker component, so it can be removed safely on deimplantation.
+    /// </summary>
+    public bool AddedUniversalLanguageSpeaker = false;
 }

--- a/Content.Shared/_EinsteinEngines/Language/Components/TranslatorImplantComponent.cs
+++ b/Content.Shared/_EinsteinEngines/Language/Components/TranslatorImplantComponent.cs
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2026 Space Station 14 Contributors
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
 using Content.Shared._EinsteinEngines.Language.Components.Translators;
 using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom.Prototype.List;
 

--- a/Resources/Prototypes/Entities/Objects/Power/powercells.yml
+++ b/Resources/Prototypes/Entities/Objects/Power/powercells.yml
@@ -201,6 +201,10 @@
   name: small-capacity nuclear power cell
   description: A self rechargeable power cell, designed for fast recharge rate at the expense of capacity.
   components:
+  - type: Tag
+    tags:
+      - PowerCellSelfRecharging
+      - PowerCellSmall
   - type: BatterySelfRecharger
     autoRecharge: true
     autoRechargeRate: 36 # 10 seconds to recharge
@@ -356,6 +360,7 @@
     - PowerCell
     - DroneUsable
     - PowerCellMicroreactor
+    - PowerCellSelfRecharging
   - type: Battery
     maxCharge: 720
     startingCharge: 720
@@ -410,6 +415,7 @@
       - PowerCell
       - DroneUsable
       - PowerCellAntique
+      - PowerCellSelfRecharging
     - type: Battery
       maxCharge: 1200
       startingCharge: 1200

--- a/Resources/Prototypes/Roles/Jobs/CentComm/deathsquad.yml
+++ b/Resources/Prototypes/Roles/Jobs/CentComm/deathsquad.yml
@@ -30,7 +30,7 @@
   - BlueshieldOfficer
   special: # Goobstation Start - I basically re-did all of deathsquads stuff so. - Sol
   - !type:AddImplantSpecial
-    implants: [ MindShieldImplant, FreedomImplant, BluespaceLifelineImplant, RadioImplantCentcomm, NutrimentPumpImplant, StypticStimulatorImplant, DeathRattleImplantCentcomm, LibrarianTranslatorImplant ]
+    implants: [ MindShieldImplant, FreedomImplant, BluespaceLifelineImplant, RadioImplantCentcomm, NutrimentPumpImplant, StypticStimulatorImplant, DeathRattleImplantCentcomm, CentcommTranslatorImplant ]
   - !type:AddComponentSpecial
     components:
     - type: DeathSquadMember # Goobstation

--- a/Resources/Prototypes/Roles/Jobs/CentComm/emergencyresponseteam.yml
+++ b/Resources/Prototypes/Roles/Jobs/CentComm/emergencyresponseteam.yml
@@ -133,7 +133,7 @@
   - BlueshieldOfficer
   special: # Goobstation
   - !type:AddImplantSpecial
-    implants: [ MindShieldImplant, FreedomImplant, BluespaceLifelineImplant, RadioImplantCentcomm, NutrimentPumpImplant, StypticStimulatorImplant, DeathRattleImplantCentcomm, LibrarianTranslatorImplant ]
+    implants: [ MindShieldImplant, FreedomImplant, BluespaceLifelineImplant, RadioImplantCentcomm, NutrimentPumpImplant, StypticStimulatorImplant, DeathRattleImplantCentcomm, CentcommTranslatorImplant ]
 
 - type: startingGear
   id: ERTLeaderGear

--- a/Resources/Prototypes/Roles/Jobs/CentComm/official.yml
+++ b/Resources/Prototypes/Roles/Jobs/CentComm/official.yml
@@ -57,7 +57,7 @@
   - BlueshieldOfficer
   special: # Goobstation
   - !type:AddImplantSpecial
-    implants: [ MindShieldImplant, FreedomImplant, BluespaceLifelineImplant, RadioImplantCentcomm, NutrimentPumpImplant, StypticStimulatorImplant, DeathRattleImplantCentcomm, LibrarianTranslatorImplant ]
+    implants: [ MindShieldImplant, FreedomImplant, BluespaceLifelineImplant, RadioImplantCentcomm, NutrimentPumpImplant, StypticStimulatorImplant, DeathRattleImplantCentcomm, CentcommTranslatorImplant ]
 
 - type: startingGear # Goobstation - Start - SolsticeOfTheWinter
   id: CentcomGear

--- a/Resources/Prototypes/Roles/Jobs/Wildcards/zookeeper.yml
+++ b/Resources/Prototypes/Roles/Jobs/Wildcards/zookeeper.yml
@@ -70,6 +70,8 @@
   - !type:GiveItemOnHolidaySpecial
     holiday: MonkeyDay
     prototype: MonkeyCubeBox
+  - !type:AddImplantSpecial
+    implants: [ ZookeeperTranslatorImplant ]
 
 - type: startingGear
   id: ZookeeperGear

--- a/Resources/Prototypes/_DV/Entities/Objects/Devices/tape_recorder.yml
+++ b/Resources/Prototypes/_DV/Entities/Objects/Devices/tape_recorder.yml
@@ -19,6 +19,16 @@
   - type: Item
     size: Small
   - type: TapeRecorder
+    understoodLanguages:
+    - TauCetiBasic
+    - SolCommon
+    - Tradeband
+    - Freespeak
+    - Elyran
+    - NovuNederic
+    - Gruntish
+    - SpaceItalian
+    - YowKriol
   - type: ActiveListener
     range: 4
   - type: UseDelay

--- a/Resources/Prototypes/_DV/Entities/Objects/Devices/tape_recorder.yml
+++ b/Resources/Prototypes/_DV/Entities/Objects/Devices/tape_recorder.yml
@@ -27,7 +27,6 @@
     - Elyran
     - NovuNederic
     - Gruntish
-    - SpaceItalian
     - YowKriol
   - type: ActiveListener
     range: 4

--- a/Resources/Prototypes/_Goobstation/Objects/Devices/translator_implants.yml
+++ b/Resources/Prototypes/_Goobstation/Objects/Devices/translator_implants.yml
@@ -74,10 +74,31 @@
   parent: BaseSubdermalImplant
   id: ZookeeperTranslatorImplant
   name: zookeeper translator implant
-  description: An implant giving the ability to understand every animal language.
+  description: An implant giving the ability to understand and speak every animal language.
   categories: [ HideSpawnMenu ]
   components:
   - type: TranslatorImplant
+    spoken:
+      - Carptongue # Animals -
+      - Cat
+      - Cheval
+      - Chicken
+      - Cow
+      - Crab
+      - Deer
+      - Dog
+      - Duck
+      - FloorGoblin
+      - Fox
+      - Hissing
+      - Kangaroo
+      - Kobold
+      - Monkey
+      - Mouse
+      - Penguin
+      - Pig
+      - Sheep
+      - Xeno
     understood:
       - Carptongue # Animals -
       - Cat

--- a/Resources/Prototypes/_Goobstation/Objects/Devices/translator_implants.yml
+++ b/Resources/Prototypes/_Goobstation/Objects/Devices/translator_implants.yml
@@ -44,6 +44,8 @@
       - Xeeplian # Abductor Language
       - Eckeckyik # Thaven Language
       - BieselEckeckyik # Bieselized Thaven Language
+      - Crab # Animal Languages -
+      - Mouse
 
     understood:
       - TauCetiBasic # Common Languages -
@@ -76,8 +78,8 @@
       - Xeeplian # Abductor Language
       - Eckeckyik # Thaven Language
       - BieselEckeckyik # Bieselized Thaven Language
-
-
+      - Crab # Animal Languages -
+      - Mouse
 
 - type: entity
   parent: BaseSubdermalImplant

--- a/Resources/Prototypes/_Goobstation/Objects/Devices/translator_implants.yml
+++ b/Resources/Prototypes/_Goobstation/Objects/Devices/translator_implants.yml
@@ -39,7 +39,11 @@
       - Draconic # = Sinta'Unathi, Reptillian Language
       - Schechi # Avali Language
       - ValyrianStandard # Harpy Language
-
+      - YowKriol # Yowie Language
+      - Eldritch # Cthulhoid Language
+      - Xeeplian # Abductor Language
+      - Eckeckyik # Thaven Language
+      - BieselEckeckyik # Bieselized Thaven Language
 
     understood:
       - TauCetiBasic # Common Languages -
@@ -67,6 +71,11 @@
       - Draconic # = Sinta'Unathi, Reptillian Language
       - Schechi # Avali Language
       - ValyrianStandard # Harpy Language
+      - YowKriol # Yowie Language
+      - Eldritch # Cthulhoid Language
+      - Xeeplian # Abductor Language
+      - Eckeckyik # Thaven Language
+      - BieselEckeckyik # Bieselized Thaven Language
 
 
 

--- a/Resources/Prototypes/_Goobstation/Objects/Devices/translator_implants.yml
+++ b/Resources/Prototypes/_Goobstation/Objects/Devices/translator_implants.yml
@@ -39,25 +39,6 @@
       - Draconic # = Sinta'Unathi, Reptillian Language
       - Schechi # Avali Language
       - ValyrianStandard # Harpy Language
-      - YowKriol # Yowie Language
-#      - Azaziba # Depricated Languages -
-#      - Delvahii
-      - Eldritch # Eventually Cthulhoid Language
-#      - NalRasan
-#      - SiikTajr
-      - BieselEckeckyik
-      - Eckeckyik # Thaven Language
-      - Xeeplian # Abductor/Xeeplian Language
-#      - YaSsa
-      - Cheval # Animal Languages -
-      - Carptongue
-      - Deer
-      - Duck
-      - Kangaroo
-      - Pig
-      - Mouse
-      - Monkey
-      - Kobold
 
 
     understood:
@@ -86,25 +67,48 @@
       - Draconic # = Sinta'Unathi, Reptillian Language
       - Schechi # Avali Language
       - ValyrianStandard # Harpy Language
-      - YowKriol # Yowie Language
-#      - Azaziba # Depricated Languages -
-#      - Delvahii
-      - Eldritch # Eventually Cthulhoid Language
-#      - NalRasan
-#      - SiikTajr
-      - BieselEckeckyik
-      - Eckeckyik # Thaven Language
-      - Xeeplian # Abductor/Xeeplian Language
-#      - YaSsa
-      - Cheval # Animal Languages -
-      - Carptongue
+
+
+
+- type: entity
+  parent: BaseSubdermalImplant
+  id: ZookeeperTranslatorImplant
+  name: zookeeper translator implant
+  description: An implant giving the ability to understand every animal language.
+  categories: [ HideSpawnMenu ]
+  components:
+  - type: TranslatorImplant
+    understood:
+      - Carptongue # Animals -
+      - Cat
+      - Cheval
+      - Chicken
+      - Cow
+      - Crab
       - Deer
+      - Dog
       - Duck
+      - FloorGoblin
+      - Fox
+      - Hissing
       - Kangaroo
-      - Pig
-      - Mouse
-      - Monkey
       - Kobold
+      - Monkey
+      - Mouse
+      - Penguin
+      - Pig
+      - Sheep
+      - Xeno
+
+- type: entity
+  parent: BaseSubdermalImplant
+  id: CentcommTranslatorImplant
+  name: central command translator implant
+  description: An implant granting the ability to understand and speak any language. Issued to high-ranking Central Command personnel.
+  categories: [ HideSpawnMenu ]
+  components:
+  - type: TranslatorImplant
+    universalLanguageSpeaker: true
 
 
 

--- a/Resources/Prototypes/_Goobstation/Objects/Misc/translator_implanters.yml
+++ b/Resources/Prototypes/_Goobstation/Objects/Misc/translator_implanters.yml
@@ -15,6 +15,22 @@
     implant: LibrarianTranslatorImplant
 
 - type: entity
+  id: CentcommTranslatorImplanter
+  parent: BaseImplantOnlyImplanterCentcomm
+  suffix: Translator
+  components:
+  - type: Implanter
+    implant: CentcommTranslatorImplant
+
+- type: entity
+  id: ZookeeperTranslatorImplanter
+  parent: [ BaseTranslatorImplanter ]
+  suffix: Zookeeper
+  components:
+  - type: Implanter
+    implant: ZookeeperTranslatorImplant
+
+- type: entity
   id: ChevalTranslatorImplanter
   parent: [ BaseTranslatorImplanter ]
   suffix: Cheval

--- a/Resources/Prototypes/_Goobstation/Xenobiology/Entities/Objects/Specific/Xenobiology/extract_items.yml
+++ b/Resources/Prototypes/_Goobstation/Xenobiology/Entities/Objects/Specific/Xenobiology/extract_items.yml
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2026 Goob Station Contributors
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 - type: entity
   id: XenobioVolatileOrgan
   parent: [ BaseHumanOrgan, BasePowerCell ]

--- a/Resources/Prototypes/_Goobstation/Xenobiology/Entities/Objects/Specific/Xenobiology/extract_items.yml
+++ b/Resources/Prototypes/_Goobstation/Xenobiology/Entities/Objects/Specific/Xenobiology/extract_items.yml
@@ -63,6 +63,7 @@
     - PowerCell
     - DroneUsable
     - Organ
+    - PowerCellSelfRecharging
 
 - type: entity
   name: goop ball

--- a/Resources/Prototypes/_Jamboree/Entities/Objects/Devices/dispensers.yml
+++ b/Resources/Prototypes/_Jamboree/Entities/Objects/Devices/dispensers.yml
@@ -31,8 +31,7 @@
         startingItem: PowerCellMedium
         blacklist:
           tags:
-          - PowerCellMicroreactor
-          - PowerCellAntique
+          - PowerCellSelfRecharging
   - type: GuideHelp
     guides:
     - Chemist
@@ -99,7 +98,7 @@
         startingItem: PowerCellHyper
         blacklist:
           tags:
-          - PowerCellMicroreactor
+          - PowerCellSelfRecharging
   - type: GuideHelp
     guides:
     - Chemicals
@@ -123,6 +122,7 @@
     reagents:
       Amnestizine: 30
       ChloralHydrate: 30
+      Charcoal: 10
       Devirate: 20
       DexalinPlus: 8
       Doxarubixadone: 20

--- a/Resources/Prototypes/_Jamboree/tags.yml
+++ b/Resources/Prototypes/_Jamboree/tags.yml
@@ -52,3 +52,6 @@
 
 - type: Tag
   id: PowerCellAntique
+
+- type: Tag
+  id: PowerCellSelfRecharging


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2021 Pieter-Jan Briers <pieterjan.briers+git@gmail.com>
SPDX-FileCopyrightText: 2021 Swept <sweptwastaken@protonmail.com>
SPDX-FileCopyrightText: 2021 mirrorcult <lunarautomaton6@gmail.com>
SPDX-FileCopyrightText: 2022 AJCM-git <60196617+AJCM-git@users.noreply.github.com>
SPDX-FileCopyrightText: 2022 Kara <lunarautomaton6@gmail.com>
SPDX-FileCopyrightText: 2023 DrSmugleaf <DrSmugleaf@users.noreply.github.com>
SPDX-FileCopyrightText: 2023 Kevin Zheng <kevinz5000@gmail.com>
SPDX-FileCopyrightText: 2024 Vasilis <vasilis@pikachu.systems>
SPDX-FileCopyrightText: 2024 lzk <124214523+lzk228@users.noreply.github.com>
SPDX-FileCopyrightText: 2025 Aiden <28298836+Aidenkrz@users.noreply.github.com>

SPDX-License-Identifier: AGPL-3.0-or-later
-->

<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- NOTE: All code submitted to this repository is ALWAYS licensed under the AGPL-3.0-or-later license. 
The REUSE Specification headers or separate .license files indicate a secondary license (e.g., MPL or MIT) solely to facilitate 
integration for projects that do not use the AGPL license. This secondary license does not replace the fact that AGPL-3.0-or-later remains the primary and binding license. 
Uncomment and modify the following line if you wish to change the license from the default of AGPL.-->
<!--- LICENSE: AGPL -->
## About the PR
<!-- What did you change? -->
So apparently, I made the mistake of not counting for EVERY micro reactor cell, apparently theres one in xenobio!

So I updated their blacklist so they wont have it anymore.

Zookeepers and Librarians have seperate translator implants. Zookeeper for animal languages and Librarian for species.

The casette player no longer is a universal translator! It can only understand some common languages, but it wont understand some languages in its transcript.
Exploit gone.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Because the casette player was cheating from the start.
Nobody likes loopholes in the emergichemical device.
And also because its cool.
## Technical details
<!-- Summary of code changes for easier review. -->

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
<img width="851" height="443" alt="image" src="https://github.com/user-attachments/assets/13cbed42-10b5-43f4-a346-e3a67d2627dd" />
<img width="373" height="170" alt="image" src="https://github.com/user-attachments/assets/e8adbfa9-82fa-44c9-b21b-3c49215c07ef" />


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- add: Added a zookeeper translator implant. Zookeepers can now understand all animal languages.
- fix: The emergichemical device no longer accepts the xenobio cell.
- tweak: Librarians now strictly understand species only languages and not animal languages.
- fix: The cassette player no longer translates all languages. It plays back the language it heard, but not the translation in its transcript.

